### PR TITLE
Properly check if graph module is installed.

### DIFF
--- a/redisgraph/datasets/iceandfire/bulk_insert.py
+++ b/redisgraph/datasets/iceandfire/bulk_insert.py
@@ -375,8 +375,13 @@ def bulk_insert(graph, host, port, password, nodes, relations, max_token_count, 
 
     # Attempt to verify that RedisGraph module is loaded
     try:
-        module_list = client.execute_command("MODULE LIST")
-        if not any(b'graph' in module_description for module_description in module_list):
+        def isModuleLoaded(module_name):
+            for module in client.execute_command("MODULE LIST"):
+                if module.get(b'name') == bytes(module_name, 'utf-8'):
+                    return True
+            return False
+
+        if not isModuleLoaded("graph"):
             print("RedisGraph module not loaded on connected server.")
             exit(1)
     except redis.exceptions.ResponseError:


### PR DESCRIPTION
Without this fix, the script always reports that the graph module is not installed.

My setup:
redis: 6.2.6
redis-py 4.0.2

This command returns a list of dicts:

```py
client.execute_command("MODULE LIST")
```

Example output:

```py
[{b'name': b'ReJSON', b'ver': 20004}, {b'name': b'rg', b'ver': 10008}, {b'name': b'graph', b'ver': 20411}]
```

The current code checks each list element for a key of value `b"graph"`. However, the only valid keys are `b"name"` and `b"ver"`.
